### PR TITLE
Add option to install on different prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 curl -s nit.lognit.com | sudo sh
 ```
 
+To install in /usr/local instead of /usr:
+
+```sh
+curl -s nit.lognit.com | PREFIX=/usr/local sudo sh
+```
+
 Installing another version:
 
 ```

--- a/install
+++ b/install
@@ -3,9 +3,13 @@
 # This is an install script. Run it!
 #
 
+if [ "$PREFIX" == ""]; then
+    PREFIX="/usr"
+fi
+
 echo "Installing Lognit command-line interface (local)..."
-cp target/lognit-cli-*.sh /usr/bin/nit
-chmod a+x /usr/bin/nit
+cp target/lognit-cli-*.sh "$PREFIX/bin/nit"
+chmod a+x "$PREFIX/bin/nit"
 
 cat << '__END__' > /tmp/nitr
 #!/bin/sh
@@ -20,8 +24,8 @@ verb=$1; shift
 resource=$1; shift
 curl -X ${verb} -s -L -H 'Content-Type:application/json' -w \\n -b ~/.lognit/state "http://${server}/rest/${resource}" $@
 __END__
-mv /tmp/nitr /usr/bin/nitr
-chmod a+x /usr/bin/nitr
+mv /tmp/nitr "$PREFIX/bin/nitr"
+chmod a+x "$PREFIX/bin/nitr"
 
 cat << '__END__' > /tmp/_nit  
 _nit()


### PR DESCRIPTION
Make install script to install binary into `$PREFIX/bin` directory. If not specified, `$PREFIX` is `/usr`.
